### PR TITLE
Add GitHub Actions workflows for building and releasing Tomcat images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/buildNext.yml
+++ b/.github/workflows/buildNext.yml
@@ -1,8 +1,8 @@
 name: Build next images
 
-# Builds and publishes the eight `next-*` xhio/xh-tomcat variants. These are
-# mutable, snapshot-style tags rebuilt on every push to develop and weekly so
-# they pick up upstream tomcat:9.0 / tomcat:10.1 base image patches.
+# Publishes the `next-*` xhio/xh-tomcat snapshot tags. Rebuilt on every push
+# to develop and weekly so they pick up upstream base image patches. See
+# README / CHANGELOG for the currently supported Tomcat + JDK matrix.
 
 on:
   push:
@@ -21,16 +21,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     concurrency:
-      group: buildNext-${{ matrix.tomcat-version }}-${{ matrix.jdk }}
+      group: buildNext-${{ matrix.tomcat.tag-prefix }}-${{ matrix.jdk }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
-      # Cartesian product of supported Tomcat x JDK versions. Tomcat
-      # version is the floating major.minor tag (e.g. 9.0) so each build picks
-      # up the latest upstream patch automatically.
+      # Supported variants: cross-product of the Tomcat lines and JDK versions
+      # listed below. Each `tomcat` entry uses the floating major.minor base
+      # tag so runs pick up the latest upstream patch automatically, and is
+      # published as `next-<tag-prefix>-jdkXX`. Add more entries to extend.
       matrix:
-        tomcat-version: ["9.0", "10.1"]
-        jdk: [jdk11, jdk17, jdk21, jdk25]
+        tomcat:
+          - { version: "10.1", tag-prefix: tc10 }
+        jdk: [jdk17, jdk25]
     steps:
       - uses: actions/checkout@v4
 
@@ -40,18 +42,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Tag suffix preserves the legacy convention: bare `next-jdkXX` for the
-      # Tomcat 9.0 line, `next-tc10-jdkXX` for the Tomcat 10.1 line.
       - name: Build and push image
         env:
-          TOMCAT_VERSION: ${{ matrix.tomcat-version }}
+          TOMCAT_VERSION: ${{ matrix.tomcat.version }}
+          TAG_PREFIX: ${{ matrix.tomcat.tag-prefix }}
           JDK_VERSION: ${{ matrix.jdk }}
         run: |
-          if [ "$TOMCAT_VERSION" = "10.1" ]; then
-            TAG="xhio/xh-tomcat:next-tc10-$JDK_VERSION"
-          else
-            TAG="xhio/xh-tomcat:next-$JDK_VERSION"
-          fi
+          TAG="xhio/xh-tomcat:next-$TAG_PREFIX-$JDK_VERSION"
           docker build --pull \
             --build-arg TOMCAT_VERSION="$TOMCAT_VERSION" \
             --build-arg JDK_VERSION="$JDK_VERSION" \

--- a/.github/workflows/buildNext.yml
+++ b/.github/workflows/buildNext.yml
@@ -1,0 +1,59 @@
+name: Build next images
+
+# Builds and publishes the eight `next-*` xhio/xh-tomcat variants. These are
+# mutable, snapshot-style tags rebuilt on every push to develop and weekly so
+# they pick up upstream tomcat:9.0 / tomcat:10.1 base image patches.
+
+on:
+  push:
+    branches: [develop]
+  schedule:
+    # 01:00 UTC Thursday ≈ Wed 20:00 EST / 21:00 EDT.
+    # Approximates the prior TeamCity "Wednesday 20:00 America/New_York" trigger
+    # (GitHub Actions cron is UTC-only with no DST awareness).
+    - cron: '0 1 * * 4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: buildNext-${{ matrix.tomcat-version }}-${{ matrix.jdk }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      # Cartesian product of supported Tomcat x JDK versions. Tomcat
+      # version is the floating major.minor tag (e.g. 9.0) so each build picks
+      # up the latest upstream patch automatically.
+      matrix:
+        tomcat-version: ["9.0", "10.1"]
+        jdk: [jdk11, jdk17, jdk21, jdk25]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Tag suffix preserves the legacy convention: bare `next-jdkXX` for the
+      # Tomcat 9.0 line, `next-tc10-jdkXX` for the Tomcat 10.1 line.
+      - name: Build and push image
+        env:
+          TOMCAT_VERSION: ${{ matrix.tomcat-version }}
+          JDK: ${{ matrix.jdk }}
+        run: |
+          if [ "$TOMCAT_VERSION" = "10.1" ]; then
+            TAG="xhio/xh-tomcat:next-tc10-$JDK"
+          else
+            TAG="xhio/xh-tomcat:next-$JDK"
+          fi
+          docker build --pull \
+            --build-arg TOMCAT_VERSION="$TOMCAT_VERSION" \
+            --build-arg JDK="$JDK" \
+            -t "$TAG" .
+          docker push "$TAG"

--- a/.github/workflows/buildNext.yml
+++ b/.github/workflows/buildNext.yml
@@ -34,10 +34,10 @@ jobs:
           - { version: "10.1", tag-prefix: tc10 }
         jdk: [jdk17, jdk25]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/buildNext.yml
+++ b/.github/workflows/buildNext.yml
@@ -45,15 +45,15 @@ jobs:
       - name: Build and push image
         env:
           TOMCAT_VERSION: ${{ matrix.tomcat-version }}
-          JDK: ${{ matrix.jdk }}
+          JDK_VERSION: ${{ matrix.jdk }}
         run: |
           if [ "$TOMCAT_VERSION" = "10.1" ]; then
-            TAG="xhio/xh-tomcat:next-tc10-$JDK"
+            TAG="xhio/xh-tomcat:next-tc10-$JDK_VERSION"
           else
-            TAG="xhio/xh-tomcat:next-$JDK"
+            TAG="xhio/xh-tomcat:next-$JDK_VERSION"
           fi
           docker build --pull \
             --build-arg TOMCAT_VERSION="$TOMCAT_VERSION" \
-            --build-arg JDK="$JDK" \
+            --build-arg JDK_VERSION="$JDK_VERSION" \
             -t "$TAG" .
           docker push "$TAG"

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           docker build \
             --pull \
-            --build-arg JDK=${{ matrix.jdk }} \
+            --build-arg JDK_VERSION=${{ matrix.jdk }} \
             -t "$VERSION_TAG" \
             -t "$LATEST_TAG" \
             .

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -1,6 +1,6 @@
 name: Build Release
 
-# Publishes a numbered xhio/xh-tomcat release. Manually triggered from main
+# Publishes a numbered xhio/xh-tomcat release. Manually triggered from master
 # (or a hotfix branch). Validates the release version, builds the release
 # variants in parallel against the pinned Tomcat patch versions in the matrix
 # below, pushes to Docker Hub with both the immutable
@@ -10,7 +10,7 @@ name: Build Release
 #
 # To release with a newer Tomcat patch: bump the `tomcat` entry in the matrix
 # below (and keep the Dockerfile TOMCAT_VERSION ARG default in sync), update
-# CHANGELOG.md in a normal PR, merge to main, then dispatch this workflow.
+# CHANGELOG.md in a normal PR, merge to master, then dispatch this workflow.
 
 on:
   workflow_dispatch:
@@ -32,9 +32,9 @@ concurrency:
 
 jobs:
   validate:
-    # Guards against accidental release from develop. Requires main for standard
-    # releases and a branch other than main (or develop) when is-hotfix is set.
-    if: github.ref != 'refs/heads/develop' && ((github.ref == 'refs/heads/main') != inputs.is-hotfix)
+    # Guards against accidental release from develop. Requires master for standard
+    # releases and a branch other than master (or develop) when is-hotfix is set.
+    if: github.ref != 'refs/heads/develop' && ((github.ref == 'refs/heads/master') != inputs.is-hotfix)
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -1,0 +1,114 @@
+name: Build Release
+
+# Builds and publishes a numbered xhio/xh-tomcat release. Manually triggered
+# from the main branch (or a hotfix branch). Validates the release version,
+# builds the jdk11 and jdk17 variants in parallel against the Tomcat patch
+# version pinned as the TOMCAT_VERSION ARG default in the Dockerfile,
+# pushes them to Docker Hub with both the immutable X.Y.Z-jdkXX tag and
+# the floating latest-jdkXX tag, then tags the commit and creates a
+# GitHub release.
+#
+# To release with a newer Tomcat patch: bump the TOMCAT_VERSION ARG default
+# in the Dockerfile and update CHANGELOG.md in a normal PR, merge to main,
+# then dispatch this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version (e.g. 3.3.0)'
+        required: true
+        type: string
+      is-hotfix:
+        description: 'As hotfix. Check when releasing a hotfix to a version other than the latest.'
+        required: true
+        default: false
+        type: boolean
+
+# Run release builds one-by-one, but never cancel a release in flight.
+concurrency:
+  group: build-release
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    # Guards against accidental release from develop. Requires main for standard
+    # releases and a branch other than main (or develop) when is-hotfix is set.
+    if: github.ref != 'refs/heads/develop' && ((github.ref == 'refs/heads/main') != inputs.is-hotfix)
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Checkout is required to be called with `fetch-depth: 0` and `fetch-tags: true`.
+      - name: Validate release version
+        uses: xh/hoist-dev-utils/.github/actions/validate-release-version@master
+        with:
+          version: ${{ inputs.version }}
+          is-hotfix: ${{ inputs.is-hotfix }}
+
+  build:
+    needs: validate
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - jdk: jdk11
+          - jdk: jdk17
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Tomcat patch version is pinned as the TOMCAT_VERSION ARG default in
+      # the Dockerfile, so we override only the JDK here.
+      - name: Build and push image
+        env:
+          VERSION_TAG: xhio/xh-tomcat:${{ inputs.version }}-${{ matrix.jdk }}
+          LATEST_TAG: xhio/xh-tomcat:latest-${{ matrix.jdk }}
+        run: |
+          docker build \
+            --pull \
+            --build-arg JDK=${{ matrix.jdk }} \
+            -t "$VERSION_TAG" \
+            -t "$LATEST_TAG" \
+            .
+          docker push "$VERSION_TAG"
+          docker push "$LATEST_TAG"
+
+  release:
+    needs: build
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Checkout is required to be called with `fetch-depth: 0` and `fetch-tags: true`.
+      - name: Create tag and GitHub release
+        uses: xh/hoist-dev-utils/.github/actions/create-tag-and-github-release@master
+        with:
+          version: ${{ inputs.version }}
+          is-hotfix: ${{ inputs.is-hotfix }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -1,16 +1,16 @@
 name: Build Release
 
-# Builds and publishes a numbered xhio/xh-tomcat release. Manually triggered
-# from the main branch (or a hotfix branch). Validates the release version,
-# builds the jdk11 and jdk17 variants in parallel against the Tomcat patch
-# version pinned as the TOMCAT_VERSION ARG default in the Dockerfile,
-# pushes them to Docker Hub with both the immutable X.Y.Z-jdkXX tag and
-# the floating latest-jdkXX tag, then tags the commit and creates a
-# GitHub release.
+# Publishes a numbered xhio/xh-tomcat release. Manually triggered from main
+# (or a hotfix branch). Validates the release version, builds the release
+# variants in parallel against the pinned Tomcat patch versions in the matrix
+# below, pushes to Docker Hub with both the immutable
+# <xh-release>-<tag-prefix>-jdkXX tag and the floating latest-<tag-prefix>-jdkXX
+# tag, then tags the commit and creates a GitHub release.
+# See README / CHANGELOG for the currently supported Tomcat + JDK matrix.
 #
-# To release with a newer Tomcat patch: bump the TOMCAT_VERSION ARG default
-# in the Dockerfile and update CHANGELOG.md in a normal PR, merge to main,
-# then dispatch this workflow.
+# To release with a newer Tomcat patch: bump the `tomcat` entry in the matrix
+# below (and keep the Dockerfile TOMCAT_VERSION ARG default in sync), update
+# CHANGELOG.md in a normal PR, merge to main, then dispatch this workflow.
 
 on:
   workflow_dispatch:
@@ -61,10 +61,15 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # Supported release variants: cross-product of the Tomcat lines and JDK
+      # versions listed below. Each `tomcat` entry pins an exact patch and a
+      # `tag-prefix` used in the published Docker tag (e.g. `tc10`). Add more
+      # entries to extend. The Dockerfile's TOMCAT_VERSION ARG default is
+      # kept in sync with the current entry for local `docker build` use.
       matrix:
-        include:
-          - jdk: jdk11
-          - jdk: jdk17
+        tomcat:
+          - { version: "10.1.54", tag-prefix: tc10 }
+        jdk: [jdk17, jdk25]
 
     steps:
       - uses: actions/checkout@v4
@@ -75,15 +80,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Tomcat patch version is pinned as the TOMCAT_VERSION ARG default in
-      # the Dockerfile, so we override only the JDK here.
       - name: Build and push image
         env:
-          VERSION_TAG: xhio/xh-tomcat:${{ inputs.version }}-${{ matrix.jdk }}
-          LATEST_TAG: xhio/xh-tomcat:latest-${{ matrix.jdk }}
+          VERSION_TAG: xhio/xh-tomcat:${{ inputs.version }}-${{ matrix.tomcat.tag-prefix }}-${{ matrix.jdk }}
+          LATEST_TAG: xhio/xh-tomcat:latest-${{ matrix.tomcat.tag-prefix }}-${{ matrix.jdk }}
         run: |
           docker build \
             --pull \
+            --build-arg TOMCAT_VERSION=${{ matrix.tomcat.version }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             -t "$VERSION_TAG" \
             -t "$LATEST_TAG" \

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -72,10 +72,10 @@ jobs:
         jdk: [jdk17, jdk25]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-Note that the `next-tc10-jdkXX` tags are mutable and are rebuilt after any updates to this project and on a weekly
-schedule. This ensures the `next` series tags pick up ongoing updates to the official `tomcat:10.1` base image.
+Note that the `next-tcXX-jdkYY` tags are mutable and are rebuilt after any updates to this project and on a weekly
+schedule. This ensures the `next-*` series tags pick up ongoing updates to the official upstream tomcat base images.
 
 Versioned builds are immutable and have locked-in the latest Tomcat version at the time of the build (recorded in the
 log entries below). These are recommended for production use in applications, to ensure a known-good version of Tomcat
@@ -11,20 +11,23 @@ See this project's README for details on how images are tagged for use with diff
 
 ## next - under development
 
-* Tomcat `10.1` (exact version dependent on build time)
+* Tomcat `10.1` tags (`next-tc10-jdk17`, `next-tc10-jdk25`)
 
-## 4.0.0 - 2026-04-20
+## 4.0.0 - 2026-05-07
 
-* **Breaking:** Dropped support for Tomcat `9.0` and JDK 11. Going forward, xh-tomcat only publishes images
-  for Tomcat `10.1` on JDK 17 and JDK 25. Apps still on the dropped versions should pin to a `3.x` release tag (e.g.
-  `3.2.0-jdk11`) until they are ready to migrate.
-* **Breaking:** Release tag scheme now includes a Tomcat-line segment. Tags are published as
-  `latest-tc10-jdkXX` and `<xh-release>-tc10-jdkXX` (e.g. `latest-tc10-jdk17`, `4.0.0-tc10-jdk17`) instead of the
-  previous `latest-jdkXX` / `<xh-release>-jdkXX`. This makes it possible to publish multiple Tomcat lines in
-  parallel in the future. Apps pulling `latest-jdk17` will need to switch to `latest-tc10-jdk17` to move forward;
-  `latest-jdk17` and earlier `3.x-jdkXX` tags remain available but will no longer be updated.
-* Added `release-tc10-jdk25` tags (`latest-tc10-jdk25`, `<xh-release>-tc10-jdk25`).
+* Added `release-tc10-jdk17` tags (`latest-tc10-jdk17`, `4.0.0-tc10-jdk25`).
+* Added `release-tc10-jdk25` tags (`latest-tc10-jdk25`, `4.0.0-tc10-jdk25`).
 * Tomcat `10.1.54`.
+
+### 💥 Breaking Changes
+* Dropped support for Tomcat `9.0` and JDK 11. Going forward, xh-tomcat only publishes images for Tomcat `10.1` 
+  on JDK 17 and JDK 25. Apps still on the dropped versions should pin to a `3.x` release tag (e.g. `3.2.0-jdk11`) 
+  until they are ready to migrate.
+* Release tag scheme changed to now always include a Tomcat-line segment. Tags are now published as `latest-tcXX-jdkYY` 
+  and `<xh-release>-tcXX-jdkYY` (e.g. `latest-tc10-jdk17`, `4.0.0-tc10-jdk17`) instead of the previous `latest-jdkXX` 
+  / `<xh-release>-jdkXX` implied to be on Tomcat `9.0`. Apps pulling `latest-jdk17` will need to switch to Tomcat 10.1
+  and `latest-tc10-jdk17` to move forward; `latest-jdk17` and earlier `3.x-jdkXX` tags remain available but will no longer 
+  be updated.
 
 ## 3.2.0 - 2025-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-Note that the `next-jdkXX` tags are mutable and are rebuilt after any updates to this project and on a weekly schedule.
-This ensures the `next` series tags pick up ongoing updates to the official `tomcat:9.0` base image.
+Note that the `next-tc10-jdkXX` tags are mutable and are rebuilt after any updates to this project and on a weekly
+schedule. This ensures the `next` series tags pick up ongoing updates to the official `tomcat:10.1` base image.
 
 Versioned builds are immutable and have locked-in the latest Tomcat version at the time of the build (recorded in the
 log entries below). These are recommended for production use in applications, to ensure a known-good version of Tomcat
@@ -11,7 +11,20 @@ See this project's README for details on how images are tagged for use with diff
 
 ## next - under development
 
-* Tomcat `9.0` (exact version dependent on build time)
+* Tomcat `10.1` (exact version dependent on build time)
+
+## 4.0.0 - 2026-04-20
+
+* **Breaking:** Dropped support for Tomcat `9.0` and JDK 11. Going forward, xh-tomcat only publishes images
+  for Tomcat `10.1` on JDK 17 and JDK 25. Apps still on the dropped versions should pin to a `3.x` release tag (e.g.
+  `3.2.0-jdk11`) until they are ready to migrate.
+* **Breaking:** Release tag scheme now includes a Tomcat-line segment. Tags are published as
+  `latest-tc10-jdkXX` and `<xh-release>-tc10-jdkXX` (e.g. `latest-tc10-jdk17`, `4.0.0-tc10-jdk17`) instead of the
+  previous `latest-jdkXX` / `<xh-release>-jdkXX`. This makes it possible to publish multiple Tomcat lines in
+  parallel in the future. Apps pulling `latest-jdk17` will need to switch to `latest-tc10-jdk17` to move forward;
+  `latest-jdk17` and earlier `3.x-jdkXX` tags remain available but will no longer be updated.
+* Added `release-tc10-jdk25` tags (`latest-tc10-jdk25`, `<xh-release>-tc10-jdk25`).
+* Tomcat `10.1.54`.
 
 ## 3.2.0 - 2025-07-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG TOMCAT_VERSION=9.0.107
+# See buildRelease for complete matrix of published TOMCAT_VERSION and JDK_VERSION.
+ARG TOMCAT_VERSION=10.1.54
 ARG JDK_VERSION=jdk17
 FROM tomcat:${TOMCAT_VERSION}-${JDK_VERSION}
 
@@ -14,5 +15,5 @@ RUN cd webapps && \
   rm -rf host-manager
 
 # Copy in customized server.xml - look for <!-- XH CUSTOMIZATION ... --> comments.
-# Note - this should be compared and updated as needed across Tomcat versions - current as of 9.0.75.
+# Note - this should be compared and updated as needed across Tomcat versions - current as of 10.1.54.
 COPY conf/server.xml /usr/local/tomcat/conf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM tomcat:9.0-jdk17
+ARG TOMCAT_VERSION=9.0.107
+ARG JDK=jdk17
+FROM tomcat:${TOMCAT_VERSION}-${JDK}
 
 # Install some useful basic utilities
 RUN apt-get update && apt-get install -y nano procps htop dnsutils

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TOMCAT_VERSION=9.0.107
-ARG JDK=jdk17
-FROM tomcat:${TOMCAT_VERSION}-${JDK}
+ARG JDK_VERSION=jdk17
+FROM tomcat:${TOMCAT_VERSION}-${JDK_VERSION}
 
 # Install some useful basic utilities
 RUN apt-get update && apt-get install -y nano procps htop dnsutils

--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@ deployments with additional configurations.
 ## Tomcat versions, JDK versions and Docker tags
 
  Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat), producing the
-variants below. In the table and prose, `<tomcat-patch>` is the pinned upstream Tomcat patch version and
-`<xh-release>` is the xh-tomcat semver release from `CHANGELOG.md`.
+variants below.
 
-| Variant            | Tomcat | JDK | Source base image             | Docker tag(s)                                    |
-|--------------------|:------:|:---:|-------------------------------|--------------------------------------------------|
-| next-tc10-jdk17    |  10.1  | 17  | `tomcat:10.1-jdk17`           | `next-tc10-jdk17`                                |
-| next-tc10-jdk25    |  10.1  | 25  | `tomcat:10.1-jdk25`           | `next-tc10-jdk25`                                |
-| release-tc10-jdk17 |  10.1  | 17  | `tomcat:<tomcat-patch>-jdk17` | `latest-tc10-jdk17`, `<xh-release>-tc10-jdk17`   |
-| release-tc10-jdk25 |  10.1  | 25  | `tomcat:<tomcat-patch>-jdk25` | `latest-tc10-jdk25`, `<xh-release>-tc10-jdk25`   |
+| Variant            | Tomcat | JDK | Source base image       | Docker tag(s)                              |
+|--------------------|:------:|:---:|-------------------------|--------------------------------------------|
+| next-tc10-jdk17    |  10.1  | 17  | `tomcat:10.1-jdk17`     | `next-tc10-jdk17`                          |
+| next-tc10-jdk25    |  10.1  | 25  | `tomcat:10.1-jdk25`     | `next-tc10-jdk25`                          |
+| release-tc10-jdk17 | 10.1.54 | 17 | `tomcat:10.1.54-jdk17`  | `latest-tc10-jdk17`, `4.0.0-tc10-jdk17`    |
+| release-tc10-jdk25 | 10.1.54 | 25 | `tomcat:10.1.54-jdk25`  | `latest-tc10-jdk25`, `4.0.0-tc10-jdk25`    |
 
 `next-*` tags are fully mutable. Every `next-tcXX-jdkYY` variant is rebuilt on every commit to `develop` and on a weekly
 schedule (Wednesday ~20:00 ET) so they pick up upstream patches to the floating Tomcat base images. They are intended for 

--- a/README.md
+++ b/README.md
@@ -6,23 +6,47 @@ Hoist's Grails based back-end) and nginx (to serve compiled client JS/CSS and ot
 This repo contains a minimal Dockerfile to build the base Tomcat container, which can be used by app-specific Docker
 deployments with additional configurations.
 
-## Tomcat version, JDK versions and Docker tags
+## Tomcat versions, JDK versions and Docker tags
 
-All images produced by this repo are currently using **Tomcat 9.0**. The specific patch version of Tomcat is baked
-into an image when it is built, based on how the source `tomcat:9.0` image resolves. We record the current full Tomcat
-version strings for versioned xh-tomcat releases in our CHANGELOG.
+Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat). We support two
+Tomcat lines (`9.0` and `10.1`) and four JDK versions (11, 17, 21, 25), producing the variants below:
 
-This repo does support multiple versions of the JDK, however, with distinct branches for each that we keep in sync
-with each other and build/publish with dedicated tags.
+| Variant             | Tomcat | JDK | Source base image    | Docker tag(s)                 |
+|---------------------|:------:|:---:|----------------------|-------------------------------|
+| next-jdk11          |  9.0   | 11  | `tomcat:9.0-jdk11`   | `next-jdk11`                  |
+| next-jdk17          |  9.0   | 17  | `tomcat:9.0-jdk17`   | `next-jdk17`                  |
+| next-jdk21          |  9.0   | 21  | `tomcat:9.0-jdk21`   | `next-jdk21`                  |
+| next-jdk25          |  9.0   | 25  | `tomcat:9.0-jdk25`   | `next-jdk25`                  |
+| next-tc10-jdk11     |  10.1  | 11  | `tomcat:10.1-jdk11`  | `next-tc10-jdk11`             |
+| next-tc10-jdk17     |  10.1  | 17  | `tomcat:10.1-jdk17`  | `next-tc10-jdk17`             |
+| next-tc10-jdk21     |  10.1  | 21  | `tomcat:10.1-jdk21`  | `next-tc10-jdk21`             |
+| next-tc10-jdk25     |  10.1  | 25  | `tomcat:10.1-jdk25`  | `next-tc10-jdk25`             |
+| release-jdk11       |  9.0   | 11  | `tomcat:A.B.C-jdk11` | `latest-jdk11`, `X.Y.Z-jdk11` |
+| release-jdk17       |  9.0   | 17  | `tomcat:A.B.C-jdk17` | `latest-jdk17`, `X.Y.Z-jdk17` |
 
-| Branch        | JDK Version | Docker Tag(s)                         |
-|---------------|:-----------:|---------------------------------------|
-| master-jdk11  |     11      | `X.Y.Z-jdk11`, `latest-jdk11`         |
-| master-jdk17  |     17      | `X.Y.Z-jdk17`, `latest-jdk17`         |
-| develop-jdk11 |     11      | `next-jdk11`                          |
-| develop-jdk17 |     17      | `next-jdk17`                          |
+`next-*` tags are fully mutable and rebuilt on every commit to `develop` and on a weekly schedule (Wednesday 20:00
+ET) so they pick up upstream patches to the floating `tomcat:9.0` / `tomcat:10.1` base images. They are intended for
+testing and snapshot-style deployments.
+
+`release-*` builds publish two tags per JDK: an immutable `X.Y.Z-jdkXX` tag pinned to a specific xh-tomcat semver
+release (recorded in `CHANGELOG.md`) and a mutable `latest-jdkXX` tag that floats to the most recent release of that
+JDK line.
+
+## Branches and CI
+
+This repo uses a single `develop` branch (and a `main` branch tracking the most recent release).
+
+GitHub Actions workflows live in [`.github/workflows/`](./.github/workflows):
+
+- **`buildNext.yml`** — runs on every push to `develop`, on a weekly schedule, and on manual dispatch. Builds and
+  pushes all `next-*` variants in parallel via a matrix.
+- **`buildRelease.yml`** — manual dispatch from `main` only. Takes a semver release version as input. The locked
+  Tomcat patch version is the `TOMCAT_VERSION` ARG default in the [`Dockerfile`](./Dockerfile). Builds and pushes
+  the `release-*` variants with both `latest-jdkXX` and `X.Y.Z-jdkXX` tags, then creates the corresponding git
+  tag and GitHub release. To release with a newer Tomcat patch, bump the `TOMCAT_VERSION` default in the Dockerfile
+  and update `CHANGELOG.md` in a normal PR before dispatching the workflow.
 
 ----
 📫☎️🌎 info@xh.io | https://xh.io/contact
 
-Copyright © 2023 Extremely Heavy Industries Inc.
+Copyright © 2026 Extremely Heavy Industries Inc.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ to the most recent release of that pair.
 
 ## Branches and CI
 
-This repo uses a single `develop` branch (and a `main` branch tracking the most recent release).
+This repo uses a single `develop` branch (and a `master` branch tracking the most recent release).
 
 GitHub Actions workflows live in [`.github/workflows/`](./.github/workflows):
 
 - **`buildNext.yml`** — runs on every push to `develop`, on a weekly schedule, and on manual dispatch. Builds and
   pushes all `next-*` variants in parallel via a matrix.
-- **`buildRelease.yml`** — manual dispatch from `main` only. Takes a semver release version as input. The locked
+- **`buildRelease.yml`** — manual dispatch from `master` only. Takes a semver release version as input. The locked
   Tomcat patch version is pinned in the workflow's build matrix (with the [`Dockerfile`](./Dockerfile)
   `TOMCAT_VERSION` ARG default kept in sync for local builds). Builds and pushes the `release-*` variants with
   both `latest-tcXX-jdkYY` and `<xh-release>-tcXX-jdkYY` tags, then creates the corresponding git tag and GitHub

--- a/README.md
+++ b/README.md
@@ -8,29 +8,25 @@ deployments with additional configurations.
 
 ## Tomcat versions, JDK versions and Docker tags
 
-Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat). We support two
-Tomcat lines (`9.0` and `10.1`) and four JDK versions (11, 17, 21, 25), producing the variants below:
+ Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat). We support
+Tomcat `10.1` on JDK 17 and JDK 25, producing the variants below. In the table and prose, `<tomcat-patch>` is the
+pinned upstream Tomcat patch version (e.g. `10.1.54`) and `<xh-release>` is the xh-tomcat semver release from
+`CHANGELOG.md` (e.g. `4.0.0`).
 
-| Variant             | Tomcat | JDK | Source base image    | Docker tag(s)                 |
-|---------------------|:------:|:---:|----------------------|-------------------------------|
-| next-jdk11          |  9.0   | 11  | `tomcat:9.0-jdk11`   | `next-jdk11`                  |
-| next-jdk17          |  9.0   | 17  | `tomcat:9.0-jdk17`   | `next-jdk17`                  |
-| next-jdk21          |  9.0   | 21  | `tomcat:9.0-jdk21`   | `next-jdk21`                  |
-| next-jdk25          |  9.0   | 25  | `tomcat:9.0-jdk25`   | `next-jdk25`                  |
-| next-tc10-jdk11     |  10.1  | 11  | `tomcat:10.1-jdk11`  | `next-tc10-jdk11`             |
-| next-tc10-jdk17     |  10.1  | 17  | `tomcat:10.1-jdk17`  | `next-tc10-jdk17`             |
-| next-tc10-jdk21     |  10.1  | 21  | `tomcat:10.1-jdk21`  | `next-tc10-jdk21`             |
-| next-tc10-jdk25     |  10.1  | 25  | `tomcat:10.1-jdk25`  | `next-tc10-jdk25`             |
-| release-jdk11       |  9.0   | 11  | `tomcat:A.B.C-jdk11` | `latest-jdk11`, `X.Y.Z-jdk11` |
-| release-jdk17       |  9.0   | 17  | `tomcat:A.B.C-jdk17` | `latest-jdk17`, `X.Y.Z-jdk17` |
+| Variant            | Tomcat | JDK | Source base image             | Docker tag(s)                                    |
+|--------------------|:------:|:---:|-------------------------------|--------------------------------------------------|
+| next-tc10-jdk17    |  10.1  | 17  | `tomcat:10.1-jdk17`           | `next-tc10-jdk17`                                |
+| next-tc10-jdk25    |  10.1  | 25  | `tomcat:10.1-jdk25`           | `next-tc10-jdk25`                                |
+| release-tc10-jdk17 |  10.1  | 17  | `tomcat:<tomcat-patch>-jdk17` | `latest-tc10-jdk17`, `<xh-release>-tc10-jdk17`   |
+| release-tc10-jdk25 |  10.1  | 25  | `tomcat:<tomcat-patch>-jdk25` | `latest-tc10-jdk25`, `<xh-release>-tc10-jdk25`   |
 
 `next-*` tags are fully mutable and rebuilt on every commit to `develop` and on a weekly schedule (Wednesday 20:00
-ET) so they pick up upstream patches to the floating `tomcat:9.0` / `tomcat:10.1` base images. They are intended for
-testing and snapshot-style deployments.
+ET) so they pick up upstream patches to the floating `tomcat:10.1` base image. They are intended for testing and
+snapshot-style deployments.
 
-`release-*` builds publish two tags per JDK: an immutable `X.Y.Z-jdkXX` tag pinned to a specific xh-tomcat semver
-release (recorded in `CHANGELOG.md`) and a mutable `latest-jdkXX` tag that floats to the most recent release of that
-JDK line.
+`release-*` builds publish two tags per (Tomcat line, JDK) pair: an immutable `<xh-release>-tc10-jdkXX` tag pinned to
+a specific xh-tomcat semver release (recorded in `CHANGELOG.md`) and a mutable `latest-tc10-jdkXX` tag that floats
+to the most recent release of that pair.
 
 ## Branches and CI
 
@@ -41,10 +37,11 @@ GitHub Actions workflows live in [`.github/workflows/`](./.github/workflows):
 - **`buildNext.yml`** — runs on every push to `develop`, on a weekly schedule, and on manual dispatch. Builds and
   pushes all `next-*` variants in parallel via a matrix.
 - **`buildRelease.yml`** — manual dispatch from `main` only. Takes a semver release version as input. The locked
-  Tomcat patch version is the `TOMCAT_VERSION` ARG default in the [`Dockerfile`](./Dockerfile). Builds and pushes
-  the `release-*` variants with both `latest-jdkXX` and `X.Y.Z-jdkXX` tags, then creates the corresponding git
-  tag and GitHub release. To release with a newer Tomcat patch, bump the `TOMCAT_VERSION` default in the Dockerfile
-  and update `CHANGELOG.md` in a normal PR before dispatching the workflow.
+  Tomcat patch version is pinned in the workflow's build matrix (with the [`Dockerfile`](./Dockerfile)
+  `TOMCAT_VERSION` ARG default kept in sync for local builds). Builds and pushes the `release-*` variants with
+  both `latest-tc10-jdkXX` and `<xh-release>-tc10-jdkXX` tags, then creates the corresponding git tag and GitHub
+  release. To release with a newer Tomcat patch, bump the matrix entry (and the Dockerfile default) and update
+  `CHANGELOG.md` in a normal PR before dispatching the workflow.
 
 ----
 📫☎️🌎 info@xh.io | https://xh.io/contact

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ deployments with additional configurations.
 
 ## Tomcat versions, JDK versions and Docker tags
 
- Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat). We support
-Tomcat `10.1` on JDK 17 and JDK 25, producing the variants below. In the table and prose, `<tomcat-patch>` is the
-pinned upstream Tomcat patch version (e.g. `10.1.54`) and `<xh-release>` is the xh-tomcat semver release from
-`CHANGELOG.md` (e.g. `4.0.0`).
+ Images are published to Docker Hub as [`xhio/xh-tomcat`](https://hub.docker.com/r/xhio/xh-tomcat), producing the
+variants below. In the table and prose, `<tomcat-patch>` is the pinned upstream Tomcat patch version and
+`<xh-release>` is the xh-tomcat semver release from `CHANGELOG.md`.
 
 | Variant            | Tomcat | JDK | Source base image             | Docker tag(s)                                    |
 |--------------------|:------:|:---:|-------------------------------|--------------------------------------------------|
@@ -20,12 +19,12 @@ pinned upstream Tomcat patch version (e.g. `10.1.54`) and `<xh-release>` is the 
 | release-tc10-jdk17 |  10.1  | 17  | `tomcat:<tomcat-patch>-jdk17` | `latest-tc10-jdk17`, `<xh-release>-tc10-jdk17`   |
 | release-tc10-jdk25 |  10.1  | 25  | `tomcat:<tomcat-patch>-jdk25` | `latest-tc10-jdk25`, `<xh-release>-tc10-jdk25`   |
 
-`next-*` tags are fully mutable and rebuilt on every commit to `develop` and on a weekly schedule (Wednesday 20:00
-ET) so they pick up upstream patches to the floating `tomcat:10.1` base image. They are intended for testing and
-snapshot-style deployments.
+`next-*` tags are fully mutable. Every `next-tcXX-jdkYY` variant is rebuilt on every commit to `develop` and on a weekly
+schedule (Wednesday ~20:00 ET) so they pick up upstream patches to the floating Tomcat base images. They are intended for 
+testing and snapshot-style deployments.
 
-`release-*` builds publish two tags per (Tomcat line, JDK) pair: an immutable `<xh-release>-tc10-jdkXX` tag pinned to
-a specific xh-tomcat semver release (recorded in `CHANGELOG.md`) and a mutable `latest-tc10-jdkXX` tag that floats
+`release-*` builds publish two tags per (Tomcat line, JDK) pair: an immutable `<xh-release>-tcXX-jdkYY` tag pinned to
+a specific xh-tomcat semver release (recorded in `CHANGELOG.md`) and a mutable `latest-tcXX-jdkYY` tag that floats
 to the most recent release of that pair.
 
 ## Branches and CI
@@ -39,7 +38,7 @@ GitHub Actions workflows live in [`.github/workflows/`](./.github/workflows):
 - **`buildRelease.yml`** — manual dispatch from `main` only. Takes a semver release version as input. The locked
   Tomcat patch version is pinned in the workflow's build matrix (with the [`Dockerfile`](./Dockerfile)
   `TOMCAT_VERSION` ARG default kept in sync for local builds). Builds and pushes the `release-*` variants with
-  both `latest-tc10-jdkXX` and `<xh-release>-tc10-jdkXX` tags, then creates the corresponding git tag and GitHub
+  both `latest-tcXX-jdkYY` and `<xh-release>-tcXX-jdkYY` tags, then creates the corresponding git tag and GitHub
   release. To release with a newer Tomcat patch, bump the matrix entry (and the Dockerfile default) and update
   `CHANGELOG.md` in a normal PR before dispatching the workflow.
 


### PR DESCRIPTION
## Summary
- Add `buildNext.yml` workflow: builds and pushes the `next-*` variants (Tomcat 10.1 × JDK 17/25) on every push to `develop`, on a weekly schedule, and on manual dispatch. Supported variants are driven by a matrix of Tomcat lines (each with a `tag-prefix`, e.g. `tc10`) × JDK suffixes so new lines can be added without workflow surgery.
- Add `buildRelease.yml` workflow: manual dispatch from `master` (or a hotfix branch) that validates the semver input, builds the `release-*` variants against the Tomcat patch pinned in the workflow's build matrix, pushes both `<xh-release>-<tag-prefix>-jdkXX` and `latest-<tag-prefix>-jdkXX` tags, then creates the matching git tag and GitHub release.
- Parameterize the Dockerfile with `TOMCAT_VERSION` and `JDK_VERSION` build args so a single Dockerfile drives every variant; defaults (`10.1.54` / `jdk17`) track the current release pin for local builds.
- Rewrite the README's tag/branch section to document the single-`develop` model, the four currently supported variants, and how to cut a release.
- Update `CHANGELOG.md` for `4.0.0`: drops Tomcat 9.0 and JDK 11, adds JDK 25, and moves release tags to the new `latest-tc10-jdkXX` / `<xh-release>-tc10-jdkXX` scheme (the `tc10` segment leaves room to publish additional Tomcat lines in parallel).
- Added standard xh dependabot.yml config to maintain the github actions.

## Next steps / testing
- [x] Add the required secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
- [ ] Merge this branch into 'develop'
- [x] Mark the develop branch as the default branch
- [ ] Dispatch `buildNext.yml` manually and confirm all 4 matrix jobs (tc10 × jdk17/jdk25) build and push to Docker Hub.
- [ ] Create a `master` branch (off develop) to match the convention used by other xh repos.
- [ ] Dispatch `buildRelease.yml` from master with version 4.0.0 to confirm validation, build, push (both `<version>-tc10-jdkXX` and `latest-tc10-jdkXX`), tagging, and GitHub release creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)